### PR TITLE
feat: remove config comments

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -6,7 +6,6 @@
     "module": "ESNext",
     "skipLibCheck": true,
 
-    /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
     "isolatedModules": true,
@@ -14,13 +13,11 @@
     "noEmit": true,
     "jsx": "react-jsx",
 
-    /* Linting */
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
 
-    /* Aliases */
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -5,14 +5,12 @@
     "module": "ESNext",
     "skipLibCheck": true,
 
-    /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
     "isolatedModules": true,
     "moduleDetection": "force",
     "noEmit": true,
 
-    /* Linting */
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,


### PR DESCRIPTION
when dynamically loading tsConfig in gitwit, `JSON.parse` fails because of the comments in the `tsconfig.json` file and it's references. Ideally, it shouldn't be there in the first place since it's a `.json` file